### PR TITLE
Vardan

### DIFF
--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -145,8 +145,8 @@ Int_t THcShowerArray::ReadDatabase( const TDatime& date )
 
   for (UInt_t j=0; j<fNColumns; j++)
     for (UInt_t i=0; i<fNRows; i++) {
-      fXPos[i][j] = fXFront - (fNRows-1)*fXStep/2 + fXStep*i;
-      fYPos[i][j] = fYFront + (fNColumns-1)*fYStep/2 - fYStep*j;
+      fXPos[i][j] = fXFront - (fNRows+1)*fXStep/2+fXStep*(i+1);
+      fYPos[i][j] = fYFront + (fNColumns+1)*fYStep/2-fYStep*(j+1);
   }
 
   fOrigin.SetXYZ(fXFront, fYFront, fZFront);
@@ -710,18 +710,16 @@ Int_t THcShowerArray::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
       ++nrAdcHits;
     }
 
-		// Should check that counter # is in range
-		if (fUsingFADC) {
-			fA[hit->fCounter-1] = hit->GetRawAdcHitPos().GetData(
-				fPedSampLow, fPedSampHigh, fDataSampLow, fDataSampHigh
-			);
-			fP[hit->fCounter-1] = hit->GetRawAdcHitPos().GetAverage(
-				fPedSampLow, fPedSampHigh
-			);
-		}
-		else {
-			fA[hit->fCounter-1] = hit->GetData(0);
-		}
+    // Should check that counter # is in range
+    if (fUsingFADC) {
+      fA[hit->fCounter-1] = hit->GetRawAdcHitPos().GetData(
+		   fPedSampLow, fPedSampHigh, fDataSampLow, fDataSampHigh);
+      fP[hit->fCounter-1] = hit->GetRawAdcHitPos().GetAverage(
+				 fPedSampLow, fPedSampHigh);
+    }
+    else {
+      fA[hit->fCounter-1] = hit->GetData(0);
+    }
 
     if(fA[hit->fCounter-1] > threshold) {
       ngood++;


### PR DESCRIPTION
    Correct mean pedestal calculations for the Aerogel detectors.
    
            In THcAerogel.cxx, mean pedestals are calculated if
            fMinPeds>0. Set fMinPeds to default zero in
            THcAerogel::InitializePedestals. Reinitialize it with
            paero_min_peds parameter in paero.param file.

    Correct computing of X and Y coordinates of blocks in the Shower part
    of SHMS calorimeter. Assume X and Y front positions in the pcal.param
    are for the center of the Shower.
